### PR TITLE
Create flatten-array.hs

### DIFF
--- a/problems/flatten-array/flatten-array.hs
+++ b/problems/flatten-array/flatten-array.hs
@@ -1,7 +1,7 @@
 ```haskell
 -- This is a classic implementation using Haskell
 
-data UnflattenedArray x = El x | List [UnflattenedArray x] -- creating the NestedList datatype
+data UnflattenedArray x = El x | List [UnflattenedArray x] -- creating the nested list / UnflattenedArray datatype
 
 -- function for flattening an array
 flatten :: UnflattenedArray x -> [x]

--- a/problems/flatten-array/flatten-array.hs
+++ b/problems/flatten-array/flatten-array.hs
@@ -1,0 +1,14 @@
+```haskell
+-- This is a classic implementation using Haskell
+
+data UnflattenedArray x = El x | List [UnflattenedArray x] -- creating the NestedList datatype
+
+-- function for flattening an array
+flatten :: UnflattenedArray x -> [x]
+flatten (El y) = [y]
+flatten (List y) = concatMap flatten y
+
+main = do
+    print (flatten (List [El 1, List [El 2, List [El 3, El 4, El 5, El 6], El 7, El 8, El 9], List [El 10]]))
+-- Output: [1,2,3,4,5,6,7,8,9,10]
+```


### PR DESCRIPTION
To make this problem a bit interesting in Haskell, one has to define his/her own datatype. Lists in Haskell are uniform meaning that they cannot store different datatypes (e.g., `[1, 'a', 2]` will not work). In this case, elements of sublists should also have the same datatypes meaning that `[[1,2], ['a', 'b'], [3,4]]` is also not possible. We would be left with boring lists like `[[1,2,3],[4,5,6],[7,8,9]]` where everything (on all access levels) has the same datatype so I defined the brand new - `Nested List datatype`. I also added a note regarding this datatype in `README`.

This datatype could also be found at https://wiki.haskell.org/99_questions/Solutions/7 where you can see the classic solution to this problem. As seen on the link above, there are lots of different approaches yet, I found this one to be one of the easiest.