### PR TITLE
Kotlin: array pair sum

### DIFF
--- a/problems/array-pair-sum/array-pair-sum.kt
+++ b/problems/array-pair-sum/array-pair-sum.kt
@@ -1,8 +1,26 @@
-fun arrayPairSum(k: Int, values: List<Int>): List<Pair<Int, Int>> =
-    mutableListOf<Pair<Int, Int>>().apply {
-        values.forEachIndexed { i, x ->
-            values.listIterator(i + 1).forEach { y ->
-                if (x + y == k) add(x to y)
-            }
-        }
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.test.assertEquals
+
+fun arrayPairSum(k: Int, values: List<Int>): List<Pair<Int, Int>> {
+    val seen = mutableSetOf<Long>()
+
+    return values.asSequence().map(Int::toLong).fold(mutableListOf()) { result, current ->
+        val target = k - current
+        if (target in seen) result.add(min(current, target).toInt() to max(current, target).toInt())
+        else seen.add(current)
+        result
     }
+}
+
+fun main(args: Array<String>) {
+    assertEquals(
+        listOf(4 to 6, 3 to 7),
+        arrayPairSum(10, listOf(3, 4, 5, 6, 7))
+    )
+
+    assertEquals(
+        listOf(3 to 5, 4 to 4, 4 to 4),
+        arrayPairSum(8, listOf(3, 4, 5, 4, 4))
+    )
+}

--- a/problems/array-pair-sum/array-pair-sum.kt
+++ b/problems/array-pair-sum/array-pair-sum.kt
@@ -1,0 +1,8 @@
+fun arrayPairSum(k: Int, values: List<Int>): List<Pair<Int, Int>> =
+    mutableListOf<Pair<Int, Int>>().apply {
+        values.forEachIndexed { i, x ->
+            values.listIterator(i + 1).forEach { y ->
+                if (x + y == k) add(x to y)
+            }
+        }
+    }


### PR DESCRIPTION
The output of this function does not match the output examples from the README because it uses a different logic. However, it produces the correct result.

1. `arrayPairSum(10, listOf(3, 4, 5, 6, 7))` gives `[(3, 7), (4, 6)]`
2. `arrayPairSum(8, listOf(3, 4, 5, 4, 4))` gives `[(3, 5), (4, 4), (4, 4), (4, 4)]`

The former is different from the latter is the same.