### PR TITLE
Update to can-scramble.php to fix #60

### DIFF
--- a/problems/can-scramble/can-scramble.php
+++ b/problems/can-scramble/can-scramble.php
@@ -1,18 +1,15 @@
 <?php
-// NOT multi-byte safe!
-
-function char_sum(string $string): int {
-    $sum = 0;
-    for ($i = 0, $l = strlen($string); $i < $l; ++$i) $sum += ord($string{$i});
-    return $sum;
+function sorted_chars(string $input): array {
+    $chars = str_split($input);
+    sort($chars);
+    return $chars;
 }
-
 function can_scramble(string $input, string $output): bool {
-    return strlen($input) === strlen($output) && char_sum($input) === char_sum($output);
+    return strlen($input) === strlen($output) && sorted_chars($input) === sorted_chars($output);
 }
-
 assert(can_scramble("abc", "abc") === true);
 assert(can_scramble("abc", "cba") === true);
 assert(can_scramble("a", "aaaaaaaaaa") === false); // Word length does not match
 assert(can_scramble("abc", "cbad") === false);     // Word length does not match
-assert(can_scramble("aab", "bba") === false);      // word length matches, character count not
+assert(can_scramble("aab", "bba") === false);      // Word length matches, character count not
+assert(can_scramble("ac", "bb") === false);        // Word length matches, wrong characters


### PR DESCRIPTION
can-scramble.php's previous solution would fail this case
```php
assert(can_scramble("ac", "bb") === false);
```
per #60 

New proposed solution converts string to character array, sorts them and compares the results.