### PR TITLE
Adding find-missing-solutions script & docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,3 +11,16 @@ Here's how to contribute:
 5. All done. Thanks for your contribution! :heart:
 
 If you get stuck at any point, please open an issue. We'll try to help you if we can.
+
+# Finding missing solutions
+
+If you're looking for problems that don't have solutions yet in the language of your choice,
+try running the [find missing solutions](./find-missing-solutions.sh) bash script. Pass it the file extension for your language 
+of choice, and it will search the problem directories for problems that don't yet have a solution in
+that language.
+
+sample usage:
+```
+chmod u+x ./find-missing-solutions.sh
+./find-missing-solutions.sh py
+```

--- a/find-missing-solutions.sh
+++ b/find-missing-solutions.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# to run this script:
+# chmod u+x
+# ./solutions-needed.sh <extension>
+
+PROBLEMS_DIR='./problems'
+EULER_DIR="./problems/euler"
+
+if [ ! $# -eq 1 ]; then
+    echo "usage: $0 <extension>"
+    exit 1
+fi
+
+EXTENSION=$1
+
+check_folder () {
+
+  # for each folder in #Problems
+  for path_to_folder in $1/*
+  do
+    folder_name="${path_to_folder##*/}"
+
+    # recurse into the EULER_DIR
+    if [ $path_to_folder == $EULER_DIR ]
+    then
+      check_folder $EULER_DIR
+    else
+
+      #NOTE: if we could rely on filenames to match the containing folders, this is more elegant
+      # filename="$path_to_folder/$folder_name.$EXTENSION"
+      # if [ ! -e $filename ]
+
+      # if there are no files with the desired extension
+      if ! compgen -G "$path_to_folder/*.$EXTENSION" > /dev/null
+      then
+          echo $path_to_folder
+      fi
+    fi
+  done
+}
+
+echo ""
+echo "The following problems do not have a solution for: .$1:"
+check_folder $PROBLEMS_DIR


### PR DESCRIPTION
I was perusing the open issues for hacktoberfest & came across #57 . 
I started clicking around looking for problems that didn't have a python solution yet, and realized it'd be easier to write a script for that. So I did. This feature isn't strictly captured on the issues page - but it was helpful to me, so I figured I'd create a PR out of it in case it might be helpful to anyone else.

### changes
- initial add of script
- adding a documentation section in Contributing.MD since that's the most likely use
   case/customer entry point for this script

### concerns:
    - script is bash only. It's a simplistic/functional choice, but won't support all
      users
    - not a lot of input parameter checking
    - this code doesn't attempt to handle the codejam directory