### PR TITLE
Update with more efficient lookup and C# tuples

### DIFF
--- a/problems/array-pair-sum/array_pair_sum.cs
+++ b/problems/array-pair-sum/array_pair_sum.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ConsoleApp1
 {
@@ -9,9 +10,9 @@ namespace ConsoleApp1
         {
             Console.WriteLine("Hello World! 12091029");
 
-            ArrayPairSum(10, new int[] { 3, 4, 5, 6, 7 }); // [[6, 4], [7, 3]]
+            ArrayPairSum(10, new int[] { 3, 4, 5, 6, 7 }); // [[4, 6], [3, 7]]
             Console.WriteLine();
-            ArrayPairSum(8, new int[] { 3, 4, 5, 4, 4 }); // [[3, 5], [4, 4], [4, 4], [4, 4]]
+            ArrayPairSum(8, new int[] { 3, 4, 5, 4, 4 }); // [[3, 5], [4, 4]]
             Console.WriteLine();
             ArrayPairSum(8, new int[] { 4 }); // []
             Console.WriteLine();
@@ -24,42 +25,25 @@ namespace ConsoleApp1
             if (input == null || input.Length < 2)
                 return new int[][] { };
 
-            Dictionary<int, int> complements = new Dictionary<int, int>();
-            for (int x = 0; x < input.Length; x++)
+            var seen = new HashSet<int>();
+            var result = new HashSet<(int x, int y)>();
+
+            for (int i = 0; i < input.Length; i++)
             {
-                if (!complements.ContainsKey(sum - input[x]) && (input[x] != sum - input[x]))
-                {
-                    complements.Add(sum - input[x], input[x]);
-                }
+                var num = input[i];
+                var target = sum - num;
+                if (!seen.Contains(target))
+                    seen.Add(num);
+                else
+                    result.Add((target, num));
             }
 
-            List<int[]> valids = new List<int[]>();
-            for (int x = 0; x < input.Length; x++)
+            foreach (var pair in result)
             {
-                if (complements.ContainsKey(input[x])
-                    && (input[x] != sum - input[x]))
-                {
-                    valids.Add(new int[] { input[x], sum - input[x] });
-                    complements.Remove(sum - input[x]);
-                }
+                Console.Write("[" + pair.x + "," + pair.y + "]; ");
             }
 
-
-            for (int v = 0; v < valids.Count; v++)
-            {
-                Console.Write("[" + valids[v][0] + "," + valids[v][1] + "]; ");
-            }
-
-
-            int[][] output = new int[valids.Count][];
-
-            int index = 0;
-            foreach (var v in valids)
-            {
-                output[index++] = new int[2] { v[0], v[1] };
-            }
-
-            return output;
+            return result.Select(pair => new int[] { pair.x, pair.y }).ToArray();
         }
     }
 }


### PR DESCRIPTION
Switching to [HashSet<T>](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1.contains?view=netframework-4.7.2#remarks),
as well as using a tuple to make the code more readable. The tuple combined with the `HashSet<T>` also ensures we only add each pair once.