### PR TITLE
adding missing scenario

### DIFF
--- a/problems/balanced-brackets/balanced-brackets.go
+++ b/problems/balanced-brackets/balanced-brackets.go
@@ -36,11 +36,7 @@ func balanced_brackets(s string) bool{
 			}
 		}
 	}
-    // if remaining queue is not empty. ex: [[(())
-    if len(queue) != 0 {
-        return false
-    }
     
-	return true
+    return len(queue) == 0
 }
 

--- a/problems/balanced-brackets/balanced-brackets.go
+++ b/problems/balanced-brackets/balanced-brackets.go
@@ -36,6 +36,11 @@ func balanced_brackets(s string) bool{
 			}
 		}
 	}
+    // if remaining queue is not empty. ex: [[(())
+    if len(queue) != 0 {
+        return false
+    }
+    
 	return true
 }
 


### PR DESCRIPTION
Lets say after for loop queue is not empty. in that case it should return false because open brackets are more then closed brackets. 
For example: [[(())